### PR TITLE
Change/infobar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+-   Remove redundant "label" from infobar props. The label is already displayed at the top of the infobar.
+
+### Fixed
+
+-   Prevent last selected node's icon from showing when selecting an edge.
+
 ## [0.1.0] - 2024-07-11
 
 ### Added
@@ -23,4 +31,4 @@ All notable changes to this project will be documented in this file.
 
 ### Removed
 
--   Example in the module the directory
+-   Examples in the module's directory

--- a/st_link_analysis/frontend/src/components/infobar.js
+++ b/st_link_analysis/frontend/src/components/infobar.js
@@ -21,6 +21,9 @@ function _updateLabel(color, label, icon) {
 function _updateProps(data) {
     const props = document.getElementById(PROPS_ID);
     props.innerHTML = Object.entries(data)
+        .filter((item) => {
+            return item[0] != "label";
+        })
         .map(([key, value]) => {
             return `
         <div class='infobar__prop'>

--- a/st_link_analysis/frontend/src/components/infobar.js
+++ b/st_link_analysis/frontend/src/components/infobar.js
@@ -14,7 +14,7 @@ function _updateLabel(color, label, icon) {
     if (icon && icon != "none") {
         label_div.lastChild.style.backgroundImage = `url(${icon})`;
     } else {
-        delete label_div.lastChild.style.backgroundImage;
+        label_div.lastChild.style.backgroundImage = "";
     }
 }
 


### PR DESCRIPTION
-   Remove redundant "label" from infobar props. The label is already displayed at the top of the infobar.
-   Prevent last selected node's icon from showing when selecting an edge.
