### PR TITLE
Feat/bidrectional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+-   Enable passing a list of events to listen to. When any of these events are triggered,
+    the event information is sent back to the Streamlit app as the component's return
+    value. The list of events can be defined using instances of the `Event` class and
+    then passed to the component's `events` parameter.
+
 ### Changed
 
 -   Remove redundant "label" from infobar props. The label is already displayed at the top of the infobar.
@@ -11,6 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Prevent last selected node's icon from showing when selecting an edge.
+-   Pass default layout paramters to cola and fcose layouts
 
 ## [0.1.0] - 2024-07-11
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # st-link-analysis
 
+[![Static Badge](https://img.shields.io/badge/GitHub-%20?&logo=github&color=grey)](https://github.com/AlrasheedA/st-link-analysis)
+[![Static Badge](https://img.shields.io/badge/PyPI-%20?&logo=pypi&color=grey&logoColor=white)](https://pypi.org/project/st-link-analysis/)
+[![Static Badge](https://img.shields.io/badge/Streamlit-%20?&logo=streamlit&color=grey&logoColor=white)](https://discuss.streamlit.io/t/new-component-interactive-graph-visualization-component-for-streamlit/73030)
+
 A custom Streamlit component for link analysis, built with Cytoscape.js and Streamlit.
 
 ## Overview
@@ -7,22 +11,22 @@ A custom Streamlit component for link analysis, built with Cytoscape.js and Stre
 This project provides a Streamlit custom component for visualizing and interacting with graph data using Cytoscape.js. It supports customizable edge and node styles, labels, colors, captions, and icons.
 
 ## Demo
+
 ![extended-example](demo.gif)
 
 A demo deployed with Render can be [accessed here](https://st-link-analysis-demo.onrender.com/).
 
 ## Features
 
-- **Customizable Node and Edge Styles**: Easily define the appearance of nodes and edges using a variety of style options.
-- **Material Icons Support**: Supports a subset of Material icons for styling nodes which can be passed by name (e.g., `icon='person'`). Arbitrary icons can still be used by passing a url (`icon='url(...)'`).
-- **Customizable Layouts**: Choose from different layout algorithms to arrange the graph elements. Currently only Cytoscape JS base layouts are supported.
-- **Interactive Features:**
-  - Fullscreen button.
-  - JSON export button.
-  - Layout refresh button.
-  - Highlights neighboring nodes or edges when an element is selected.
-  - View all properties of the selected elements in a sidebar.
-
+-   **Customizable Node and Edge Styles**: Easily define the appearance of nodes and edges using a variety of style options.
+-   **Material Icons Support**: Supports a subset of Material icons for styling nodes which can be passed by name (e.g., `icon='person'`). Arbitrary icons can still be used by passing a url (`icon='url(...)'`).
+-   **Customizable Layouts**: Choose from different layout algorithms to arrange the graph elements. Currently only Cytoscape JS base layouts are supported.
+-   **Interactive Features:**
+    -   Fullscreen button.
+    -   JSON export button.
+    -   Layout refresh button.
+    -   Highlights neighboring nodes or edges when an element is selected.
+    -   View all properties of the selected elements in a sidebar.
 
 ## Installation
 
@@ -84,23 +88,23 @@ st_link_analysis(elements, "cose", node_styles, edge_styles)
 | ------------------ | --------------------------------------------------------------------------------------------------------------- |
 | `NodeStyle`        | Defines styles for nodes, including labels, colors, captions, and icons. Refer to docstring.                    |
 | `EdgeStyle`        | Defines styles for edges, including curve styles, labels, colors, and directionality. Refer to docstring.       |
+| `Event`            | Define an event to pass to component constructor and listen to. Use sparingly Refer to docstring.               |
 | `st_link_analysis` | Main component for creating and displaying the graph, including layout and height settings. Refer to docstring. |
-
 
 ## Development
 
-- Ensure you have Python 3.9+, Node.js, and npm installed.
-- Clone this repository
-- Navigate to root directory
+-   Ensure you have Python 3.9+, Node.js, and npm installed.
+-   Clone this repository
+-   Navigate to root directory
 
 ### Python Setup
 
 Create and activate a virtual environment, then install the package in editable mode:
 
 ```bash
-python3 -m venv .venv 
+python3 -m venv .venv
 source .venv/bin/activate # On Windows use `.venv\Scripts\activate`
-pip install -e . 
+pip install -e .
 ```
 
 ### Node Setup
@@ -109,18 +113,22 @@ Navigate to the frontend directory and install the necessary npm packages:
 
 ```bash
 cd st_link_analysis/frontend
-npm install 
+npm install
 ```
+
 ### Running the App
 
-Change `RELEASE` flag in `st_link_analysis/component/component.py` to `False`. 
+Change `RELEASE` flag in `st_link_analysis/component/component.py` to `False`.
 
 In one terminal start the frontend dev server
+
 ```bash
 cd st_link_analysis/frontend
-npm run start 
+npm run start
 ```
-In another terminal run the streamlit server 
+
+In another terminal run the streamlit server
+
 ```bash
 cd examples
 streamlit run app.py
@@ -129,6 +137,7 @@ streamlit run app.py
 ### Testing
 
 Install the testing requirements and run linting and tests:
+
 ```bash
 pip install tests/requirements.txt
 ruff check
@@ -145,6 +154,6 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Acknowledgments
 
-- [Cytoscape.js](https://js.cytoscape.org/)
-- [Streamlit](https://www.streamlit.io/)
-- [Material Icons](https://fonts.google.com/icons)
+-   [Cytoscape.js](https://js.cytoscape.org/)
+-   [Streamlit](https://www.streamlit.io/)
+-   [Material Icons](https://fonts.google.com/icons)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ st_link_analysis(elements, "cose", node_styles, edge_styles)
 | ------------------ | --------------------------------------------------------------------------------------------------------------- |
 | `NodeStyle`        | Defines styles for nodes, including labels, colors, captions, and icons. Refer to docstring.                    |
 | `EdgeStyle`        | Defines styles for edges, including curve styles, labels, colors, and directionality. Refer to docstring.       |
-| `Event`            | Define an event to pass to component constructor and listen to. Use sparingly Refer to docstring.               |
+| `Event`            | Define an event to pass to component function and listen to. Use sparingly Refer to docstring.                  |
 | `st_link_analysis` | Main component for creating and displaying the graph, including layout and height settings. Refer to docstring. |
 
 ## Development

--- a/examples/app.py
+++ b/examples/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 
 st.set_page_config(layout="wide")
 
-# ------------ Home ------------
+# ------------- Home -------------
 home = st.Page(
     "./docs/readme.py",
     title="README",
@@ -21,16 +21,28 @@ node_style = st.Page(
 edge_style = st.Page(
     "./demos/edge_style.py",
     title="Edge Styles",
-)
+)  #TODO: use multi-edge graph example for edge styles
 layout = st.Page(
     "./demos/layout.py",
     title="Layout Algorithms",
 )
 
+#TODO: Return Selection
+
+# --------- Advanced Usage ---------
+event_listeners = st.Page(
+    "./demos/event_listeners.py",
+    title="Events Listeners",
+)
+
+#TODO: Further Styling
+#TODO: Customized Layouts
+
 pg = st.navigation(
     {
         "Documentation": [home, license],
         "Demos": [node_style, edge_style, layout],
+        "Advanced Usage": [event_listeners],
     }
 )
 pg.run()

--- a/examples/app.py
+++ b/examples/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 
 st.set_page_config(layout="wide")
 
-# ------------- Home -------------
+# ------------- Docs -------------
 home = st.Page(
     "./docs/readme.py",
     title="README",
@@ -11,6 +11,11 @@ home = st.Page(
 license = st.Page(
     "./docs/license.py",
     title="LICENSE",
+)
+
+changelog = st.Page(
+    "./docs/changelog.py",
+    title="CHANGELOG",
 )
 
 # -------- Examples / Demos --------
@@ -40,7 +45,7 @@ event_listeners = st.Page(
 
 pg = st.navigation(
     {
-        "Documentation": [home, license],
+        "Documentation": [home, changelog, license],
         "Demos": [node_style, edge_style, layout],
         "Advanced Usage": [event_listeners],
     }

--- a/examples/demos/event_listeners.py
+++ b/examples/demos/event_listeners.py
@@ -1,0 +1,102 @@
+import json
+import streamlit as st
+from st_link_analysis import st_link_analysis, NodeStyle, EdgeStyle, Event
+
+with open("./data/social.json", "r") as f:
+    elements = json.load(f)
+
+if hasattr(st.session_state, "counter"):
+    st.session_state.counter += 1
+else:
+    st.session_state.counter = 1
+
+st.markdown("# Events Listeners")
+st.markdown(
+    """
+    A list of events to listen to.  When any of these events are triggered,
+    the event information is sent back to the Streamlit app as the component's
+    return value. Each event can be defined using `Event` class which takes the
+    following paramters:
+     - **name:** User defined name which will be included in the return value to help identify the event
+     - **event_type:** A space separated list of cytoscape.js events names to listen to (e.g.`click tap`). 
+        For a full list of event types refer to [Cytoscape.js events](https://js.cytoscape.org/#events)
+     - **selector:** A selector to specify elements for which the event handler runs (e.g. `node`). 
+        For specification details refer to [Cytoscape.js selectors](https://js.cytoscape.org/#selectors)
+    """
+)
+
+st.warning(
+    "**NOTE:** event listners are only configured once. For changes in its configuration to take effect, you need to remount the componet."
+)
+
+st.markdown("The following example uses two events.")
+st.code(
+    """
+    events = [
+        Event("clicked_node", "click tap", "node"),
+        Event("another_name", "dblclick dbltap", "*"),
+    ]""",
+    language="python",
+)
+st.markdown("**Total Number of runs:** %i" % st.session_state.counter)
+
+
+node_styles = [
+    NodeStyle("PERSON", "#FF7F3E", "email", "person"),
+    NodeStyle("POST", "#2A629A", "created_at", "description"),
+]
+
+edge_styles = [
+    EdgeStyle("FOLLOWS", labeled=True, directed=True),
+    EdgeStyle("POSTED", labeled=True, directed=True),
+    EdgeStyle("QUOTES", labeled=True, directed=True),
+]
+
+events = [
+    Event("clicked_node", "click tap", "node"),
+    Event("another_name", "dblclick dbltap", "*"),
+]
+
+layout = "fcose"
+with st.container(border=True):
+    vals = st_link_analysis(
+        elements, layout, node_styles, edge_styles, events=events, key="xyz"
+    )
+    st.markdown("#### Returned Value")
+    st.json(vals or {}, expanded=True)
+
+with st.expander("Snippet", expanded=False, icon="💻"):
+    st.code(
+        f"""
+        import streamlit as st
+        from st_link_analysis import st_link_analysis, NodeStyle, EdgeStyle, Event
+        
+        node_styles = [
+            NodeStyle("PERSON", "#FF7F3E", "email", "person"),
+            NodeStyle("POST", "#2A629A", "created_at", "description"),
+        ]
+
+        edge_styles = [
+            EdgeStyle("FOLLOWS", labeled=True, directed=True),
+            EdgeStyle("POSTED", labeled=True, directed=True),
+            EdgeStyle("QUOTES", labeled=True, directed=True),
+        ]
+
+        layout = "fcose"
+
+        elements = {json.dumps(elements)}
+
+        events = [
+            Event("clicked_node", "click tap", "node"),
+            Event("another_name", "dblclick dbltap", "*"),
+        ]
+
+        with st.container(border=True):
+            vals = st_link_analysis(
+                elements, layout, node_styles, edge_styles, events=events, key="xyz"
+            )
+            st.markdown("#### Returned Value")
+            st.json(vals or {{}}, expanded=True)
+    """,
+        language="python",
+    )

--- a/examples/docs/changelog.py
+++ b/examples/docs/changelog.py
@@ -1,0 +1,11 @@
+import streamlit as st
+import re
+
+with open("./../CHANGELOG.md") as f:
+    changelog = f.read()
+
+changelog = re.sub(r"(\n##) (.+)", r"\n---\n \1 :blue[\2]", changelog)
+
+changelog = changelog.replace("##", "####")
+
+st.markdown(changelog, unsafe_allow_html=True)

--- a/examples/docs/changelog.py
+++ b/examples/docs/changelog.py
@@ -5,7 +5,7 @@ with open("./../CHANGELOG.md") as f:
     changelog = f.read()
 
 changelog = re.sub(r"(\n##) (.+)", r"\n---\n \1 :blue[\2]", changelog)
+changelog = changelog.replace("##", "####").replace("# Changelog", "")
 
-changelog = changelog.replace("##", "####")
-
-st.markdown(changelog, unsafe_allow_html=True)
+st.markdown("## Changelog")
+st.markdown(changelog, unsafe_allow_html=False)

--- a/st_link_analysis/__init__.py
+++ b/st_link_analysis/__init__.py
@@ -1,4 +1,5 @@
 from st_link_analysis.component.component import st_link_analysis
 from st_link_analysis.component.styles import NodeStyle, EdgeStyle
+from st_link_analysis.component.events import Event
 
-__all__ = ["st_link_analysis", "NodeStyle", "EdgeStyle"]
+__all__ = ["st_link_analysis", "NodeStyle", "EdgeStyle", "Event"]

--- a/st_link_analysis/component/component.py
+++ b/st_link_analysis/component/component.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 from st_link_analysis.component.layouts import LAYOUTS
 from st_link_analysis.component.styles import NodeStyle, EdgeStyle
+from st_link_analysis.component.events import Event
 
 _RELEASE = True
 
@@ -28,6 +29,7 @@ def st_link_analysis(
     edge_styles: list[EdgeStyle] = [],
     height: int = 500,
     key: Optional[str] = None,
+    events: list[Event] = [],
 ) -> None:
     """
     Renders a link analysis graph using Cytoscape in Streamlit.
@@ -54,6 +56,11 @@ def st_link_analysis(
         instances of the component to exist in the same Streamlit app without
         conflicts. Setting this parameter is also important to avoid unnecessary
         re-rendering of the component.
+    events: list[Event]
+        For advanced usage only. A list of events to listen to.  When any of these
+        events are triggered, the event information is sent back to the Streamlit
+        app as the component's return value. NOTE: only defined once. Changing the
+        list of events requires remounting the component.
 
     Returns
     -------
@@ -70,6 +77,13 @@ def st_link_analysis(
     if isinstance(layout, str):
         layout = LAYOUTS[layout]
 
+    events = [e.dump() for e in events]
+
     return _component_func(
-        elements=elements, style=style, layout=layout, height=height, key=key
+        elements=elements,
+        style=style,
+        layout=layout,
+        height=height,
+        key=key,
+        events=events,
     )

--- a/st_link_analysis/component/events.py
+++ b/st_link_analysis/component/events.py
@@ -1,0 +1,42 @@
+"""
+For more details refer to https://js.cytoscape.org/#events
+"""
+
+
+class Event:
+    def __init__(
+        self,
+        name: str,
+        event_type: str,
+        selector: str,
+    ) -> None:
+        """
+        Define an event to pass to component constructor and listen to.
+
+        Parameters
+        ----------
+        name: str
+            User defined name which will be included in the return value to help
+            identify the event
+        event_type: str
+            A space separated list of cytoscape.js events names to listen to
+            (e.g."click tap"). For a full list of event types refer to
+            https://js.cytoscape.org/#events
+        selector: str
+            A selector to specify elements for which the event handler runs
+            (e.g. "node"). For specification details refer to https://js.cytoscape.org/#selectors
+
+        Example
+        ----------
+        >>> e1 = Event("clicked_node", "click tap", "node")
+        """
+        self.name = name
+        self.event_type = event_type
+        self.selector = selector
+
+    def dump(self) -> dict:
+        return {
+            "name": self.name,
+            "event_type": self.event_type,
+            "selector": self.selector,
+        }

--- a/st_link_analysis/component/layouts.py
+++ b/st_link_analysis/component/layouts.py
@@ -42,9 +42,11 @@ LAYOUTS = {
         "directed": True,
     },
     "fcose": {
+        **DEFAULT_ATTRS,
         "name": "fcose",
     },
     "cola": {
+        **DEFAULT_ATTRS,
         "name": "cola",
     },
 }

--- a/st_link_analysis/frontend/src/index.js
+++ b/st_link_analysis/frontend/src/index.js
@@ -36,14 +36,14 @@ function onRender(event) {
     newStyle = JSON.stringify(args["style"]) + theme.base;
     newLayout = JSON.stringify(args["layout"]);
     newHeight = args["height"];
-    // set height first
+    // Set height first
     if (newHeight != height) {
         height = newHeight;
         document.getElementById("container").style.height = height;
     }
-    // initialize cytoscape instance once
+    // Initialize cytoscape instance once
     if (!cy) {
-        cy = initCyto();
+        cy = initCyto(args["events"]);
     }
     // Only update if changes detected
     if (newElements != elements) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,12 +17,11 @@ def run_streamlit():
             "--server.headless",
             "true",
             "--browser.gatherUsageStats",
-            "false"
+            "false",
         ],
         cwd="./examples",
     )
-    print("hi")
-    time.sleep(3)
+    time.sleep(5)
     try:
         yield 1
     finally:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,70 @@
+from playwright.sync_api import Page
+import json
+
+
+PAGE_NAME = "Events Listeners"
+NODE_ID = "n4"
+EDGE_ID = "e2"
+ASSIGN_CY = "const cy = document.getElementById('cy')._cyreg.cy;"
+FRAME_LOCATOR = "iframe[title*='st_link_analysis']"
+
+
+def get_node_pos(_id, iframe):
+    pos = iframe.evaluate(f"""() => {{
+        {ASSIGN_CY}
+        return cy.getElementById("{_id}").renderedPosition();
+    }}""")
+    return pos
+
+
+def get_edge_pos(_id, iframe):
+    pos = iframe.evaluate(f"""() => {{
+        {ASSIGN_CY}
+        return cy.getElementById("{_id}").renderedMidpoint();
+    }}""")
+    return pos
+
+
+def get_return_json(page: Page):
+    data = page.get_by_test_id("stJson").text_content().replace('""', '","')
+    return json.loads(data)
+
+
+def test_single_click_node_event(page: Page):
+    page.get_by_role("link", name=PAGE_NAME).click()
+    frame = page.frame_locator(FRAME_LOCATOR).first.locator(":root")
+    frame.click(position={"x": 0, "y": 0})  # await and scroll to view
+
+    pos = get_node_pos(NODE_ID, frame)
+    frame.click(position=pos)
+    page.wait_for_timeout(300)
+    data = get_return_json(page)
+    assert data["event"]["target_id"] == NODE_ID
+    assert data["event"]["target_group"] == "nodes"
+    assert data["event"]["name"] == "clicked_node"
+
+
+def test_double_click_edge_event(page: Page):
+    page.get_by_role("link", name=PAGE_NAME).click()
+    frame = page.frame_locator(FRAME_LOCATOR).first.locator(":root")
+    frame.click(position={"x": 0, "y": 0})  # await and scroll to view
+
+    pos = get_edge_pos(EDGE_ID, frame)
+    frame.dblclick(position=pos)
+    page.wait_for_timeout(300)
+    data = get_return_json(page)
+    assert data["event"]["target_id"] == EDGE_ID
+    assert data["event"]["target_group"] == "edges"
+    assert data["event"]["name"] == "another_name"
+
+
+def test_single_click_edge_no_event(page: Page):
+    page.get_by_role("link", name=PAGE_NAME).click()
+    frame = page.frame_locator(FRAME_LOCATOR).first.locator(":root")
+    frame.click(position={"x": 0, "y": 0})  # await and scroll to view
+
+    pos = get_edge_pos(EDGE_ID, frame)
+    frame.click(position=pos)
+    page.wait_for_timeout(250)
+    data = get_return_json(page)
+    assert data == {}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -30,6 +30,13 @@ def get_return_json(page: Page):
     return json.loads(data)
 
 
+def test_iframe_exists_events(page: Page):
+    page.get_by_role("link", name=PAGE_NAME).click()
+    page.wait_for_load_state("networkidle")
+    frames = page.query_selector_all(FRAME_LOCATOR)
+    assert len(frames) == 1
+
+
 def test_single_click_node_event(page: Page):
     page.get_by_role("link", name=PAGE_NAME).click()
     frame = page.frame_locator(FRAME_LOCATOR).first.locator(":root")


### PR DESCRIPTION
Enable passing a list of events to listen to. When any of these events are triggered, the event information is sent back to the Streamlit app as the component's return value. The list of events can be defined using instances of the `Event` class and then passed to the component's `events` parameter. 

Partially resolves #13 (support callbacks)


https://github.com/user-attachments/assets/fc5abc81-6c9d-4d36-9750-5a0843104425

