### PR TITLE
Expand/Remove Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
     value. The list of events can be defined using instances of the `Event` class and
     then passed to the component's `events` parameter.
 -   Preview of the list of supported icons in the demo.
+-   Optional (using `extended_toolbar` paramter) remove/expand toolbar buttons that will
+    send action type and selected elements to Streamlit app as the componenet's return value.
 
 ### Changed
 

--- a/examples/docs/supported_icons.py
+++ b/examples/docs/supported_icons.py
@@ -1,37 +1,22 @@
 import streamlit as st
 from pathlib import Path
+import base64
 
 
-def prepare_svg(svg: Path) -> str:
-    return f"""\
-        <tr>
-            <td>{svg.stem}</td>
-            <td>{svg.read_text().replace("#f0f0f0", "grey")}</td>
-        </tr> """
+def prepare_icon(icon):
+    icon = icon.read_text().replace("#f0f0f0", "grey").encode("utf-8")
+    icon = base64.b64encode(icon).decode("utf-8")
+    return f"data:image/svg+xml;base64,{icon}"
 
 
 icons = Path("./../st_link_analysis/frontend/src/assets/icons").glob("*svg")
 icons = sorted(list(icons), key=lambda x: x.stem)
-icons = "".join([prepare_svg(icon) for icon in icons])
-icons = f"""\
-<html>
-    <head>
-        <style>
-            table {{
-                margin: 0 auto;
-                width: 80%;
-            }}
-        </style>
-    </head>
-    <table>
-        <tr>
-            <th>Name</th>
-            <th>Icon</th>
-        </tr>
-        {icons}
-    </table>
-</html>
-"""
+icons = [{"name": icon.stem, "preview": prepare_icon(icon)} for icon in icons]
+n_icons = len(icons)
 
 st.markdown("## Supported Icons")
-st.markdown(icons, unsafe_allow_html=True)
+st.dataframe(
+    icons,
+    width=300,
+    height=(n_icons + 1) * 35 + 2,
+    column_config={"preview": st.column_config.ImageColumn()})

--- a/st_link_analysis/frontend/src/components/graph.js
+++ b/st_link_analysis/frontend/src/components/graph.js
@@ -1,4 +1,3 @@
-import { Streamlit } from "streamlit-component-lib";
 import cytoscape from "cytoscape";
 import fcose from "cytoscape-fcose";
 import cola from "cytoscape-cola";

--- a/st_link_analysis/frontend/src/components/graph.js
+++ b/st_link_analysis/frontend/src/components/graph.js
@@ -3,7 +3,7 @@ import cytoscape from "cytoscape";
 import fcose from "cytoscape-fcose";
 import cola from "cytoscape-cola";
 import State from "../utils/state";
-import { debounce, getCyInstance } from "../utils/helpers";
+import { debounce, getCyInstance, setStreamlitValue } from "../utils/helpers";
 import STYLES from "../utils/styles";
 
 // Register cytoscape extensions
@@ -15,9 +15,9 @@ const CY_ID = "cy";
 const SELECT_DEBOUNCE = 100;
 const SET_VALUE_DEBOUNCE = 200;
 
-// Debounced Streamlit.setComponentValue
-const setComponentValue = debounce(
-    Streamlit.setComponentValue,
+// Debounced setStreamlitValue
+const setStreamlitValueDebounced = debounce(
+    setStreamlitValue,
     SET_VALUE_DEBOUNCE
 );
 
@@ -41,14 +41,14 @@ function initCyto(listeners) {
             L.event_type,
             L.selector,
             (e) => {
-                setComponentValue({
-                    event: {
-                        name: L.name,
+                setStreamlitValueDebounced({
+                    action: L.name,
+                    data: {
                         type: e.type,
                         target_id: e.target.id(),
                         target_group: e.target.group(),
-                        timestamp: e.timeStamp,
                     },
+                    timestamp: Date.now(),
                 });
             },
             Math.max(L.debounce, 100)

--- a/st_link_analysis/frontend/src/index.html
+++ b/st_link_analysis/frontend/src/index.html
@@ -25,7 +25,7 @@
             <div id="toolbar" class="toolbar">
                 <div
                     id="toolbarRefresh"
-                    class="toolbar__item i-refresh"
+                    class="toolbar__item"
                     title="Refresh Layout"
                 >
                     <!-- prettier-ignore -->
@@ -33,8 +33,25 @@
                 </div>
                 <hr class="toolbar__hr" />
                 <div
+                    id="toolbarExpand"
+                    class="toolbar__item"
+                    title="Expand Node"
+                >
+                    <!-- prettier-ignore -->
+                    <svg xmlns="http://www.w3.org/2000/svg" class="toolbar__icon" viewBox="0 -960 960 960"><path d="M480-80 310-250l57-57 73 73v-166h80v165l72-73 58 58L480-80ZM250-310 80-480l169-169 57 57-72 72h166v80H235l73 72-58 58Zm460 0-57-57 73-73H560v-80h165l-73-72 58-58 170 170-170 170ZM440-560v-166l-73 73-57-57 170-170 170 170-57 57-73-73v166h-80Z"/></svg>
+                </div>
+                <div
+                    id="toolbarRemove"
+                    class="toolbar__item"
+                    title="Remove Elements"
+                >
+                    <!-- prettier-ignore -->
+                    <svg xmlns="http://www.w3.org/2000/svg" class="toolbar__icon" viewBox="0 -960 960 960"><path d="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z"/></svg>
+                </div>
+                <hr class="toolbar__hr" />
+                <div
                     id="toolbarExport"
-                    class="toolbar__item i-save"
+                    class="toolbar__item"
                     title="Download as JSON"
                 >
                     <!-- prettier-ignore -->
@@ -43,7 +60,7 @@
                 <hr class="toolbar__hr" />
                 <div
                     id="toolbarFullscreen"
-                    class="toolbar__item i-fs"
+                    class="toolbar__item"
                     title="Fullscreen"
                 >
                     <!-- prettier-ignore -->

--- a/st_link_analysis/frontend/src/index.js
+++ b/st_link_analysis/frontend/src/index.js
@@ -18,10 +18,6 @@ State.subscribe("selection", graph.updateHighlight);
 State.subscribe("layout", graph.updateLayout);
 State.subscribe("style", graph.updateStyle);
 
-// Initialize components
-initToolbar();
-initViewbar();
-
 // Initialize variables for onRender
 let cy;
 let elements, newElements;
@@ -44,6 +40,8 @@ function onRender(event) {
     // Initialize cytoscape instance once
     if (!cy) {
         cy = initCyto(args["events"]);
+        initToolbar(args["extended_toolbar"]);
+        initViewbar();
     }
     // Only update if changes detected
     if (newElements != elements) {

--- a/st_link_analysis/frontend/src/style.css
+++ b/st_link_analysis/frontend/src/style.css
@@ -30,7 +30,7 @@ body[data-theme="dark"] {
 }
 
 html {
-    font-size: clamp(8px, 3px + 1vw, 14px);
+    font-size: clamp(8px, 4px + 1vw, 14px);
 }
 
 body {
@@ -63,10 +63,11 @@ body {
     z-index: 2;
     box-sizing: border-box;
     position: absolute;
-    top: 0rem;
-    bottom: 0rem;
+    top: 0;
+    left: 0;
+    bottom: 0;
     margin: 0.5rem;
-    width: 0rem;
+    width: 0;
     transition-duration: 200ms;
     /* content */
     display: flex;
@@ -91,7 +92,7 @@ body {
 .infobar__help {
     position: absolute;
     bottom: calc(50% - 5rem);
-    left: 0rem;
+    left: 0;
     height: auto;
     transform: rotate(-90deg);
     transform-origin: left top;
@@ -159,10 +160,9 @@ body {
 /* ---------------------------------------------------- */
 .toolbar {
     z-index: 2;
-    box-sizing: border-box;
     position: absolute;
-    top: 0rem;
-    right: 0rem;
+    top: 0;
+    right: 0;
     margin: 0.5rem;
     height: 2rem;
     width: auto;
@@ -176,6 +176,7 @@ body {
 .toolbar__item {
     width: 2rem;
     height: 2rem;
+    cursor: pointer;
     /* content */
     vertical-align: middle;
     display: flex;
@@ -191,14 +192,14 @@ body {
 }
 
 .toolbar__hr {
-    margin: 0.25rem 0 0.25rem 0;
-    border: var(--neutral-8) solid 0.5px;
+    margin: 0;
+    border: var(--neutral-3) solid 0.5px;
 }
 
 .toolbar__icon {
     fill: var(--neutral-9);
-    height: 65%;
-    width: 65%;
+    height: 60%;
+    width: 60%;
     margin: auto;
 }
 
@@ -225,6 +226,7 @@ body {
     display: flex;
     vertical-align: middle;
     align-items: center;
+    cursor: pointer;
     &:hover {
         background-color: var(--neutral-3);
     }

--- a/st_link_analysis/frontend/src/utils/helpers.js
+++ b/st_link_analysis/frontend/src/utils/helpers.js
@@ -1,3 +1,5 @@
+import { Streamlit } from "streamlit-component-lib";
+
 function debounce(func, wait) {
     let timeout;
     return function (...args) {
@@ -15,4 +17,12 @@ function getCyInstance() {
     return cy;
 }
 
-export { debounce, getCyInstance };
+function setStreamlitValue({ action, data, timestamp } = {}) {
+    Streamlit.setComponentValue({
+        action: action,
+        data: data,
+        timestamp: timestamp,
+    });
+}
+
+export { debounce, getCyInstance, setStreamlitValue };

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -26,7 +26,12 @@ def get_edge_pos(_id, iframe):
 
 
 def get_return_json(page: Page):
-    data = page.get_by_test_id("stJson").text_content().replace('""', '","')
+    data = (
+        page.get_by_test_id("stJson")
+        .text_content()
+        .replace('""', '","')
+        .replace('}"', '},"')
+    )
     return json.loads(data)
 
 
@@ -46,9 +51,9 @@ def test_single_click_node_event(page: Page):
     frame.click(position=pos)
     page.wait_for_timeout(300)
     data = get_return_json(page)
-    assert data["event"]["target_id"] == NODE_ID
-    assert data["event"]["target_group"] == "nodes"
-    assert data["event"]["name"] == "clicked_node"
+    assert data["data"]["target_id"] == NODE_ID
+    assert data["data"]["target_group"] == "nodes"
+    assert data["action"] == "clicked_node"
 
 
 def test_double_click_edge_event(page: Page):
@@ -60,9 +65,9 @@ def test_double_click_edge_event(page: Page):
     frame.dblclick(position=pos)
     page.wait_for_timeout(300)
     data = get_return_json(page)
-    assert data["event"]["target_id"] == EDGE_ID
-    assert data["event"]["target_group"] == "edges"
-    assert data["event"]["name"] == "another_name"
+    assert data["data"]["target_id"] == EDGE_ID
+    assert data["data"]["target_group"] == "edges"
+    assert data["action"] == "another_name"
 
 
 def test_single_click_edge_no_event(page: Page):


### PR DESCRIPTION
Add optional (using `extended_toolbar` paramter) remove/expand toolbar buttons that will send action type and selected elements to Streamlit app as the componenet's return value. See #13 