### PR TITLE
Node Expansion Dynamics

### DIFF
--- a/examples/demos/event_listeners.py
+++ b/examples/demos/event_listeners.py
@@ -71,38 +71,14 @@ with st.container(border=True):
     st.markdown("#### Returned Value")
     st.json(vals or {}, expanded=True)
 
-with st.expander("Snippet", expanded=False, icon="💻"):
-    st.code(
-        f"""
-        import streamlit as st
-        from st_link_analysis import st_link_analysis, NodeStyle, EdgeStyle, Event
-        
-        node_styles = [
-            NodeStyle("PERSON", "#FF7F3E", "email", "person"),
-            NodeStyle("POST", "#2A629A", "created_at", "description"),
-        ]
+@st.cache_data
+def get_source():
+    with open(__file__, "r") as f:
+        source = f.read()
+    return source
 
-        edge_styles = [
-            EdgeStyle("FOLLOWS", labeled=True, directed=True),
-            EdgeStyle("POSTED", labeled=True, directed=True),
-            EdgeStyle("QUOTES", labeled=True, directed=True),
-        ]
 
-        layout = "fcose"
+source = get_source()
+with st.expander("Source", expanded=False, icon="💻"):
+    st.code(source, language="python")
 
-        elements = {json.dumps(elements)}
-
-        events = [
-            Event("clicked_node", "click tap", "node"),
-            Event("another_name", "dblclick dbltap", "*"),
-        ]
-
-        with st.container(border=True):
-            vals = st_link_analysis(
-                elements, layout, node_styles, edge_styles, events=events, key="xyz"
-            )
-            st.markdown("#### Returned Value")
-            st.json(vals or {{}}, expanded=True)
-    """,
-        language="python",
-    )

--- a/examples/demos/node_actions.py
+++ b/examples/demos/node_actions.py
@@ -1,6 +1,9 @@
 import json
 import streamlit as st
 from st_link_analysis import st_link_analysis, NodeStyle, EdgeStyle
+from st_link_analysis.component.layouts import LAYOUTS
+
+LAYOUT_NAMES = list(LAYOUTS.keys())
 
 st.markdown("# Expand / Remove Nodes")
 st.error(
@@ -96,7 +99,7 @@ COMPONENT_KEY = "NODE_ACTIONS"
 if not hasattr(st.session_state, "graph"):
     st.session_state.graph = DummyGraph()
 
-layout = "fcose"
+layout = st.selectbox("Try with different layouts", LAYOUT_NAMES, index=0)
 
 node_styles = [
     NodeStyle("PERSON", "#FF7F3E", "email", "person"),
@@ -132,90 +135,14 @@ with st.container(border=True):
     st.markdown("#### Returned Value")
     st.json(vals or {}, expanded=True)
 
+
+@st.cache_data
+def get_source():
+    with open(__file__, "r") as f:
+        source = f.read()
+    return source
+
+
+source = get_source()
 with st.expander("Source", expanded=False, icon="💻"):
-    st.code(
-        """
-import json
-import streamlit as st
-from st_link_analysis import st_link_analysis, NodeStyle, EdgeStyle
-
-
-class DummyGraph:
-    def __init__(self):
-        with open("./data/company.json", "r") as f:
-            elements = json.load(f)
-        self.all_nodes = elements["nodes"]
-        self.all_edges = elements["edges"]
-        self.nodes = set([n["data"]["id"] for n in elements["nodes"]])
-        self.edges = set([e["data"]["id"] for e in elements["edges"]])
-
-    def get_elements(self):
-        return {
-            "nodes": [n for n in self.all_nodes if n["data"]["id"] in self.nodes],
-            "edges": [e for e in self.all_edges if e["data"]["id"] in self.edges],
-        }
-
-    def remove(self, node_ids):
-        self.nodes -= set(node_ids)
-        self._update_edges()
-
-    def expand(self, node_ids):
-        new_nodes = set()
-        node_ids = set(node_ids)
-        for e in self.all_edges:
-            if e["data"]["source"] in node_ids:  # outbound
-                new_nodes.add(e["data"]["target"])
-            elif e["data"]["target"] in node_ids:  # inbound
-                new_nodes.add(e["data"]["source"])
-        self.nodes |= new_nodes
-        self._update_edges()
-
-    def _update_edges(self):
-        self.edges = {
-            e["data"]["id"]
-            for e in self.all_edges
-            if e["data"]["source"] in self.nodes and e["data"]["target"] in self.nodes
-        }
-
-
-COMPONENT_KEY = "NODE_ACTIONS"
-
-if not hasattr(st.session_state, "graph"):
-    st.session_state.graph = DummyGraph()
-
-layout = "fcose"
-
-node_styles = [
-    NodeStyle("PERSON", "#FF7F3E", "email", "person"),
-    NodeStyle("COMPANY", "#2A629A", "name", "business"),
-]
-
-edge_styles = [
-    EdgeStyle("WORKS_AT", labeled=True, directed=True),
-    EdgeStyle("OWNED_BY", labeled=True, directed=True),
-]
-
-
-def onchange_callback():
-    val = st.session_state[COMPONENT_KEY]
-
-    if val["action"] == "remove":
-        st.session_state.graph.remove(val["data"]["node_ids"])
-
-    elif val["action"] == "expand":
-        st.session_state.graph.expand(val["data"]["node_ids"])
-
-
-elements = st.session_state.graph.get_elements()
-
-st_link_analysis(
-    elements,
-    layout=layout,
-    node_styles=node_styles,
-    key=COMPONENT_KEY,
-    enable_node_actions=True,
-    on_change=onchange_callback,
-)
-    """,
-        language="python",
-    )
+    st.code(source, language="python")

--- a/examples/demos/node_actions.py
+++ b/examples/demos/node_actions.py
@@ -6,12 +6,6 @@ from st_link_analysis.component.layouts import LAYOUTS
 LAYOUT_NAMES = list(LAYOUTS.keys())
 
 st.markdown("# Expand / Remove Nodes")
-st.error(
-    """
-    **Alpha Release**: the feature is still under development. Mainly exploring how to make node expansions smooth. If you have any suggestions please share via [Github](https://github.com/AlrasheedA/st-link-analysis).
-    """,
-    icon="🚨",
-)
 st.markdown(
     """
     The `enable_node_actions` parameter allows for interactive expansion and removal of

--- a/st_link_analysis/frontend/src/components/nodeActions.js
+++ b/st_link_analysis/frontend/src/components/nodeActions.js
@@ -9,6 +9,33 @@ const IDS = {
 const DELAYS = {
     default: 150,
 };
+const expandLayout = {
+    name: "fcose",
+    animationDuration: 500,
+    randomize: false,
+    fit: false,
+    nodeDimensionsIncludeLabels: true,
+    uniformNodeDimensions: false,
+    numIter: 50,
+    tile: false,
+};
+
+function animateNeighbors(parent, neighbors) {
+    const pos = parent.position();
+    const layout = {
+        ...expandLayout,
+        fixedNodeConstraint: [
+            {
+                nodeId: parent.id(),
+                position: pos,
+            },
+        ],
+    };
+    neighbors.position(pos);
+    neighbors.addClass("highlight");
+    parent.connectedEdges().addClass("highlight");
+    getCyInstance().layout(layout).run();
+}
 
 function _handleRemove() {
     const nodes = State.getState("selection").selected?.filter("node");
@@ -24,6 +51,7 @@ function _handleRemove() {
             timestamp: Date.now(),
         });
         nodes.unselect();
+        State.updateState("lastExpanded", false);
     }
 }
 
@@ -35,6 +63,7 @@ function _handleExpand() {
             data: { node_ids: [node.id()] },
             timestamp: Date.now(),
         });
+        State.updateState("lastExpanded", node);
     }
 }
 
@@ -70,4 +99,5 @@ function initNodeActions(enableNodeActions) {
     document.body.setAttribute("tabindex", "0");
 }
 
+export { animateNeighbors };
 export default initNodeActions;

--- a/st_link_analysis/frontend/src/components/nodeActions.js
+++ b/st_link_analysis/frontend/src/components/nodeActions.js
@@ -15,7 +15,7 @@ const expandLayout = {
     randomize: false,
     fit: false,
     nodeDimensionsIncludeLabels: true,
-    uniformNodeDimensions: false,
+    uniformNodeDimensions: true,
     numIter: 50,
     tile: false,
 };

--- a/st_link_analysis/frontend/src/index.js
+++ b/st_link_analysis/frontend/src/index.js
@@ -5,7 +5,7 @@ import { debounce } from "./utils/helpers.js";
 import initCyto, { graph } from "./components/graph.js";
 import initToolbar from "./components/toolbar.js";
 import initViewbar from "./components/viewbar.js";
-import initNodeActions from "./components/nodeActions.js";
+import initNodeActions, { animateNeighbors } from "./components/nodeActions.js";
 import updateInfopanel from "./components/infopanel.js";
 
 // Constants / Configurations
@@ -46,8 +46,22 @@ function onRender(event) {
     // Elements dynamic update
     if (newElements != elements) {
         elements = newElements;
-        cy.json({ elements: args["elements"] });
+        const lastExpanded = State.getState("lastExpanded");
+        if (lastExpanded === false) {
+            // default behavior
+            cy.json({ elements: args["elements"] });
+        } else {
+            // if nodeActions enabled & last action === expand
+            const newNodes = cy
+                .add([
+                    ...args["elements"]["nodes"],
+                    ...args["elements"]["edges"],
+                ])
+                .filter("node");
+            animateNeighbors(lastExpanded, newNodes);
+        }
     }
+    State.updateState("lastExpanded", false);
 
     // Style dynamic update
     if (newStyle != style) {

--- a/st_link_analysis/frontend/src/utils/helpers.js
+++ b/st_link_analysis/frontend/src/utils/helpers.js
@@ -25,6 +25,6 @@ function setStreamlitValue({ action, data, timestamp } = {}) {
     });
 }
 
-const debouncedSetValue = debounce(setStreamlitValue, 150);
+const debouncedSetValue = debounce(setStreamlitValue, 100);
 
 export { debounce, getCyInstance, debouncedSetValue };

--- a/st_link_analysis/frontend/src/utils/state.js
+++ b/st_link_analysis/frontend/src/utils/state.js
@@ -13,11 +13,13 @@ class StateManager {
                 custom_style: [],
             },
             layout: null,
+            lastExpanded: false,
         };
         this.observers = {
             selection: [],
             style: [],
             layout: [],
+            lastExpanded: [],
         };
         StateManager.instance = this;
         return this;

--- a/tests/test_node_actions.py
+++ b/tests/test_node_actions.py
@@ -42,7 +42,7 @@ def test_expand_dblclick(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.dblclick(position=pos)
-    page.wait_for_timeout(500)
+    page.wait_for_timeout(750)
     data = get_return_json(page)
     assert data["action"] == "expand"
     assert data["data"]["node_ids"][0] == NODE_ID
@@ -55,9 +55,9 @@ def test_expand_button(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(200)
+    page.wait_for_timeout(250)
     frame.get_by_title("Expand Node").click()
-    page.wait_for_timeout(500)
+    page.wait_for_timeout(750)
     data = get_return_json(page)
     assert data["action"] == "expand"
     assert data["data"]["node_ids"][0] == NODE_ID
@@ -70,9 +70,9 @@ def test_remove_keydown(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(200)
+    page.wait_for_timeout(250)
     page.keyboard.down("Delete")
-    page.wait_for_timeout(500)
+    page.wait_for_timeout(750)
     data = get_return_json(page)
     assert data["action"] == "remove"
     assert data["data"]["node_ids"][0] == NODE_ID
@@ -85,9 +85,9 @@ def test_remove_button(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(200)
+    page.wait_for_timeout(250)
     frame.get_by_title("Remove Nodes").click()
-    page.wait_for_timeout(500)
+    page.wait_for_timeout(750)
     data = get_return_json(page)
     assert data["action"] == "remove"
     assert data["data"]["node_ids"][0] == NODE_ID


### PR DESCRIPTION
Introduce expansions dynamics for node-actions feature. This should address #20

The current approach: 
- Keep track of the expanded node and its newly added neighbors
- Place the neighbors at the parent node position
- Fix the parent node position (supported by `fcose` layout)
- Run the layout with randomization set to false and limited number of iterations 
- Highlight new nodes


https://github.com/user-attachments/assets/ddbfeb19-517b-4b0c-9ff0-45d0105d3c05


