### PR TITLE
Minimize use of wait_for_timeout in tests

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -23,5 +23,5 @@ runs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-        pip install ruff pytest-playwright
+        pip install ruff pytest-playwright pytest-rerunfailures
         playwright install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+-   Reduce use of `wait_for_timeout` in tests by replacing it with selectors where
+    appropriate, allowing Playwright to handle waiting automatically.
+
 ## [0.2.0] - 2024-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 -   Reduce use of `wait_for_timeout` in tests by replacing it with selectors where
     appropriate, allowing Playwright to handle waiting automatically.
+    ([#25](https://github.com/AlrasheedA/st-link-analysis/pull/25))
+-   Add pytest reruns to to avoid manual retrying of CI flaky tests.
+    ([#25](https://github.com/AlrasheedA/st-link-analysis/pull/25))
 
 ## [0.2.0] - 2024-08-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ indent-width = 4
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F"]
 fixable = ["ALL"]
+
+[tool.pytest.ini_options]
+addopts = "--reruns=3"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -49,8 +49,9 @@ def test_single_click_node_event(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(300)
+    page.get_by_text('"action":"').click() # awaits for action
     data = get_return_json(page)
+
     assert data["data"]["target_id"] == NODE_ID
     assert data["data"]["target_group"] == "nodes"
     assert data["action"] == "clicked_node"
@@ -63,8 +64,9 @@ def test_double_click_edge_event(page: Page):
 
     pos = get_edge_pos(EDGE_ID, frame)
     frame.dblclick(position=pos)
-    page.wait_for_timeout(300)
+    page.get_by_text('"action":"').click() # awaits for action
     data = get_return_json(page)
+
     assert data["data"]["target_id"] == EDGE_ID
     assert data["data"]["target_group"] == "edges"
     assert data["action"] == "another_name"
@@ -77,6 +79,7 @@ def test_single_click_edge_no_event(page: Page):
 
     pos = get_edge_pos(EDGE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(250)
+    page.wait_for_timeout(500) # await to ensure no event
     data = get_return_json(page)
+
     assert data == {}

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 import json
 
 
@@ -8,6 +8,12 @@ EDGE_ID = "e2"
 ASSIGN_CY = "const cy = document.getElementById('cy')._cyreg.cy;"
 FRAME_LOCATOR = "iframe[title*='st_link_analysis']"
 
+def AWAIT_RETURN_ACTION(page):
+    page.get_by_text('"action":"').click()
+
+def AWAIT_SELECT(frame):
+    infopanel_label = frame.locator('#infopanelLabel')
+    expect(infopanel_label).to_be_visible()
 
 def get_node_pos(_id, iframe):
     pos = iframe.evaluate(f"""() => {{
@@ -49,7 +55,7 @@ def test_single_click_node_event(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.get_by_text('"action":"').click() # awaits for action
+    AWAIT_RETURN_ACTION(page)
     data = get_return_json(page)
 
     assert data["data"]["target_id"] == NODE_ID
@@ -64,7 +70,7 @@ def test_double_click_edge_event(page: Page):
 
     pos = get_edge_pos(EDGE_ID, frame)
     frame.dblclick(position=pos)
-    page.get_by_text('"action":"').click() # awaits for action
+    AWAIT_RETURN_ACTION(page)
     data = get_return_json(page)
 
     assert data["data"]["target_id"] == EDGE_ID
@@ -79,7 +85,7 @@ def test_single_click_edge_no_event(page: Page):
 
     pos = get_edge_pos(EDGE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(500) # await to ensure no event
+    AWAIT_SELECT(frame)
     data = get_return_json(page)
 
     assert data == {}

--- a/tests/test_node_actions.py
+++ b/tests/test_node_actions.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 import json
 import re
 
@@ -8,6 +8,12 @@ NODE_ID = "c"
 ASSIGN_CY = "const cy = document.getElementById('cy')._cyreg.cy;"
 FRAME_LOCATOR = "iframe[title*='st_link_analysis']"
 
+def AWAIT_RETURN_ACTION(page):
+    page.get_by_text('"action":"').click()
+
+def AWAIT_SELECT(frame):
+    infopanel_label = frame.locator('#infopanelLabel')
+    expect(infopanel_label).to_be_visible()
 
 def get_node_pos(_id, iframe):
     pos = iframe.evaluate(f"""() => {{
@@ -16,9 +22,8 @@ def get_node_pos(_id, iframe):
     }}""")
     return pos
 
-
 def get_return_json(page: Page):
-    page.get_by_text('"action":"').click() # awaits for action
+    AWAIT_RETURN_ACTION(page)
     data = (
         page.get_by_test_id("stJson")
         .text_content()
@@ -43,6 +48,7 @@ def test_expand_dblclick(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.dblclick(position=pos)
+    AWAIT_SELECT(frame)
     page.get_by_text('"action":"').click() # awaits for action
     data = get_return_json(page)
 
@@ -57,6 +63,7 @@ def test_expand_button(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
+    AWAIT_SELECT(frame)
     frame.get_by_title("Expand Node").click()
     data = get_return_json(page)
 
@@ -71,7 +78,7 @@ def test_remove_keydown(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(500) # await for selection
+    AWAIT_SELECT(frame)
     page.keyboard.down("Delete")
     data = get_return_json(page)
 
@@ -86,6 +93,7 @@ def test_remove_button(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
+    AWAIT_SELECT(frame)
     frame.get_by_title("Remove Nodes").click()
     data = get_return_json(page)
 

--- a/tests/test_node_actions.py
+++ b/tests/test_node_actions.py
@@ -18,6 +18,7 @@ def get_node_pos(_id, iframe):
 
 
 def get_return_json(page: Page):
+    page.get_by_text('"action":"').click() # awaits for action
     data = (
         page.get_by_test_id("stJson")
         .text_content()
@@ -42,8 +43,9 @@ def test_expand_dblclick(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.dblclick(position=pos)
-    page.wait_for_timeout(750)
+    page.get_by_text('"action":"').click() # awaits for action
     data = get_return_json(page)
+
     assert data["action"] == "expand"
     assert data["data"]["node_ids"][0] == NODE_ID
 
@@ -55,10 +57,9 @@ def test_expand_button(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(250)
     frame.get_by_title("Expand Node").click()
-    page.wait_for_timeout(750)
     data = get_return_json(page)
+
     assert data["action"] == "expand"
     assert data["data"]["node_ids"][0] == NODE_ID
 
@@ -70,10 +71,10 @@ def test_remove_keydown(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(250)
+    page.wait_for_timeout(500) # await for selection
     page.keyboard.down("Delete")
-    page.wait_for_timeout(750)
     data = get_return_json(page)
+
     assert data["action"] == "remove"
     assert data["data"]["node_ids"][0] == NODE_ID
 
@@ -85,9 +86,8 @@ def test_remove_button(page: Page):
 
     pos = get_node_pos(NODE_ID, frame)
     frame.click(position=pos)
-    page.wait_for_timeout(250)
     frame.get_by_title("Remove Nodes").click()
-    page.wait_for_timeout(750)
     data = get_return_json(page)
+
     assert data["action"] == "remove"
     assert data["data"]["node_ids"][0] == NODE_ID


### PR DESCRIPTION
Reduce use of `wait_for_timeout` in tests by replacing it with selectors where appropriate, allowing Playwright to handle waiting automatically.