### PR TITLE
feat(node-actions): allow selection of actions to enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+-   Added `node_actions` paramter to allow users to list which node actions to
+    enable (e.g. `remove`, `expand`, or both).
+    ([#28](https://github.com/AlrasheedA/st-link-analysis/pull/28))
+
 ### Changed
 
 -   Reduce use of `wait_for_timeout` in tests by replacing it with selectors where
@@ -11,6 +17,14 @@ All notable changes to this project will be documented in this file.
     ([#25](https://github.com/AlrasheedA/st-link-analysis/pull/25))
 -   Add pytest reruns to to avoid manual retrying of CI flaky tests.
     ([#25](https://github.com/AlrasheedA/st-link-analysis/pull/25))
+
+### Deprecated
+
+-   Depreceated the use of `enable_node_actions` paramter. `node_actions` should be
+    used instead to enable node actions. If `enable_node_actions` is set to True
+    and `node_actions` is not provided, default actions ('remove', 'expand')
+    will be enabled.
+    ([#28](https://github.com/AlrasheedA/st-link-analysis/pull/28))
 
 ## [0.2.0] - 2024-08-03
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ A demo deployed with Render can be [accessed here](https://st-link-analysis-demo
 ## Features
 
 -   **Customizable Node and Edge Styles**: Easily define the appearance of nodes and edges using a variety of style options.
--   **Material Icons Support**: Supports a subset of Material icons for styling nodes which can be passed by name (e.g., `icon='person'`). Arbitrary icons can still be used by passing a url (`icon='url(...)'`).
--   **Customizable Layouts**: Choose from different layout algorithms to arrange the graph elements. Currently only Cytoscape JS base layouts are supported.
+-   **Material Icons Support**: Supports a subset of Material icons for styling nodes which can be passed by name (e.g., `icon='person'`). Custom icons can still be used by passing a URL (e.g., `icon='url(...)'`).
+-   **Customizable Layouts**: Choose from different layout algorithms to arrange the graph elements.
 -   **Interactive Features:**
-    -   Fullscreen button.
-    -   JSON export button.
-    -   Layout refresh button.
+    -   Toolbar with fullscreen, JSON export, and layout refresh buttons.
+    -   View control bar for zooming, fitting, and centering the view, making it easier to navigate your graphs.
+    -   View all properties of the selected elements in a side panel.
     -   Highlights neighboring nodes or edges when an element is selected.
-    -   View all properties of the selected elements in a sidebar.
+-   **Node Actions (Expand / Remove):** Enable node removal and expansion using the `node_actions` parameter. Removal can be triggered by a delete keydown or a remove button click, while expansion occurs on a double-click or expand button click. When these events are triggered, the event details and selected node IDs are sent back to the Streamlit app as the component’s return value.
 
 ## Installation
 

--- a/examples/demos/node_actions.py
+++ b/examples/demos/node_actions.py
@@ -8,8 +8,8 @@ LAYOUT_NAMES = list(LAYOUTS.keys())
 st.markdown("# Expand / Remove Nodes")
 st.markdown(
     """
-    The `enable_node_actions` parameter allows for interactive expansion and removal of
-    nodes in the graph. When enabled, the triggered events are sent back to the Streamlit
+    The `node_actions` parameter allows for interactive expansion and removal of
+    nodes in the graph. When used, the triggered events are sent back to the Streamlit
     app along with the selected node IDs, allowing developers to handle the necessary
     updates to the graph elements.
      - Removal is triggered by delete/backspace keydown or remove button click. 
@@ -34,7 +34,7 @@ st.code(
             node_ids = val["data"]["node_ids"]
             # .. handle remove 
 
-    st_link_analysis(elements, enable_node_actions=True, on_change=my_call_back, key="mygraph") 
+    st_link_analysis(elements, node_actions=['remove', 'expand'], on_change=my_call_back, key="mygraph")
         """,
     language="python",
 )
@@ -123,7 +123,7 @@ with st.container(border=True):
         layout=layout,
         node_styles=node_styles,
         key=COMPONENT_KEY,
-        enable_node_actions=True,
+        node_actions=['remove', 'expand'],
         on_change=onchange_callback,
     )
     st.markdown("#### Returned Value")

--- a/st_link_analysis/component/component.py
+++ b/st_link_analysis/component/component.py
@@ -1,10 +1,20 @@
 import os
+import warnings
 import streamlit.components.v1 as components
-from typing import Optional, Union, Callable
+from typing import Optional, Union, Callable, Literal
 
 from st_link_analysis.component.layouts import LAYOUTS
 from st_link_analysis.component.styles import NodeStyle, EdgeStyle
 from st_link_analysis.component.events import Event
+
+
+# TODO: remove in next version
+class LinkAnalysisDeprecationWarning(DeprecationWarning):
+    pass
+
+
+warnings.simplefilter("once", LinkAnalysisDeprecationWarning)
+
 
 _RELEASE = True
 
@@ -30,9 +40,9 @@ def st_link_analysis(
     height: int = 500,
     key: Optional[str] = None,
     on_change: Optional[Callable[..., None]] = None,
-    enable_node_actions: bool = False,
+    node_actions: list[Literal["remove", "expand"]] = [],
+    enable_node_actions: Optional[bool] = None,  # deprecated
     events: list[Event] = [],
-
 ) -> None:
     """
     Renders a link analysis graph using Cytoscape in Streamlit.
@@ -41,44 +51,42 @@ def st_link_analysis(
     ----------
     elements : dict
         Graph elements data including nodes and edges. Each node should have
-        an 'id', and 'name'. Each edge should have an 'id', 'source', 'target',
+        an 'id', and 'label'. Each edge should have an 'id', 'source', 'target',
         and 'label'.
-    layout : str or dict, default 'cose'
+    layout : Union[str, dict], default 'cose'
         Layout configuration for Cytoscape. If a string is provided, it
         specifies the layout name. If a dictionary is provided, it should
         contain layout options. Default is "cose". A list of support layouts and
         default settings is available in `st_link_analysis.component.layout`
-    node_styles : list[NodeStyle], optional
+    node_styles : list[NodeStyle], default []
         A list of custom NodeStyle instances to apply styles to node groups in the graph
-    edge_styles : list[EdgeStyle], optional
+    edge_styles : list[EdgeStyle], default []
         A list of custom EdgeStyle instances to apply styles to edge groups in the graph
     height: int, default 500
         Component's height in pixels. NOTE: only defined once. Changing the value
         requires remounting the component.
-    key : str, optional
+    key : str, default None
         A unique key for the component. If provided, this key allows multiple
         instances of the component to exist in the same Streamlit app without
         conflicts. Setting this parameter is also important to avoid unnecessary
         re-rendering of the component.
-    enable_node_actions: bool, default False
-        For advanced usage only. Enable node removal and expansion. Removal is triggered
-        by delete keydown or remove button click. Expansion is triggered by node double
-        click or expand button click. When any of these events are triggered the event
-        is sent back along with selected node IDs to the Streamlit app as the
-        component's return value. NOTE: only defined once. Changing the value requires
-        remounting the component. CAUTION: keeping an edge with missing source or target
-        IDs will lead to an error.
-    events: list[Event]
+    node_actions: list[Literal['remove', 'expand']], default []
+        Specifies the actions to enable for nodes. Valid options are 'remove' and
+        'expand'. 'remove' allows nodes to be removed via delete keydown or a remove
+        button click. 'expand' allows nodes to be expanded via double-click or an expand
+        button click. When any of these actions are triggered, the event information is
+        sent back to the Streamlit app as the component's return value. CAUTION: keeping
+        an edge with missing source or target IDs will lead to an error.
+    enable_node_actions: bool, default None (deprecated)
+        This parameter is deprecated and will be removed in a future release. Use
+        `node_actions` instead to enable node actions. If `enable_node_actions` is set
+        to True and `node_actions` is not provided, default actions ('remove', 'expand')
+        will be enabled.
+    events: list[Event], default []
         For advanced usage only. A list of events to listen to.  When any of these
         events are triggered, the event information is sent back to the Streamlit
         app as the component's return value. NOTE: only defined once. Changing the
         list of events requires remounting the component.
-
-    Returns
-    -------
-    None
-        This function does not return anything. It renders the Cytoscape component in the
-        Streamlit app.
     """
     node_styles = [n.dump() for n in node_styles]
     edge_styles = [e.dump() for e in edge_styles]
@@ -91,6 +99,16 @@ def st_link_analysis(
 
     events = [e.dump() for e in events]
 
+    # TODO: remove in next version along with imports, docs, and signature
+    if enable_node_actions is not None:
+        warnings.warn(
+            "Paramter `enable_node_actions` is deprecated and will be removed in a future release. "
+            "Please use the `node_actions` parameter instead.",
+            LinkAnalysisDeprecationWarning,
+        )
+    if enable_node_actions and not node_actions:
+        node_actions = ["remove", "expand"]
+
     return _component_func(
         elements=elements,
         style=style,
@@ -98,6 +116,6 @@ def st_link_analysis(
         height=height,
         key=key,
         on_change=on_change,
-        enableNodeActions=enable_node_actions,
+        nodeActions=node_actions,
         events=events,
     )

--- a/st_link_analysis/frontend/src/components/nodeActions.js
+++ b/st_link_analysis/frontend/src/components/nodeActions.js
@@ -72,31 +72,38 @@ const nodeActionsHandlers = {
     expand: debounce(_handleExpand, DELAYS.default),
 };
 
-function initNodeActions(enableNodeActions) {
-    if (enableNodeActions === false) {
+function initNodeActions(nodeActions) {
+    if (nodeActions.length === 0) {
         const nodeActions = document.getElementById("nodeActions");
         nodeActions.style.display = "none";
         return;
     }
 
-    // 'REMOVE' triggers
-    document.addEventListener("keydown", (e) => {
-        if (["Delete", "Backspace"].includes(e.key)) {
-            nodeActionsHandlers.remove();
-        }
-    });
-    document
-        .getElementById(IDS.remove)
-        .addEventListener("click", nodeActionsHandlers.remove);
+    if (nodeActions.includes("remove")) {
+        const remove = document.getElementById(IDS.remove);
+        remove.addEventListener("click", nodeActionsHandlers.remove);
+        remove.style.display = "flex";
+        // keydown event
+        document.addEventListener("keydown", (e) => {
+            if (["Delete", "Backspace"].includes(e.key)) {
+                nodeActionsHandlers.remove();
+            }
+        });
+        // focus for keydown events
+        document.body.setAttribute("tabindex", "0");
+    }
 
-    // 'EXPAND' triggers
-    getCyInstance().on("dblclick dbltap", "node", nodeActionsHandlers.expand);
-    document
-        .getElementById(IDS.expand)
-        .addEventListener("click", nodeActionsHandlers.expand);
-
-    // focus for keydown events
-    document.body.setAttribute("tabindex", "0");
+    if (nodeActions.includes("expand")) {
+        const expand = document.getElementById(IDS.expand);
+        expand.addEventListener("click", nodeActionsHandlers.expand);
+        expand.style.display = "flex";
+        // dobule click event
+        getCyInstance().on(
+            "dblclick dbltap",
+            "node",
+            nodeActionsHandlers.expand
+        );
+    }
 }
 
 export { animateNeighbors };

--- a/st_link_analysis/frontend/src/index.js
+++ b/st_link_analysis/frontend/src/index.js
@@ -39,7 +39,7 @@ function onRender(event) {
         cy = initCyto(args["events"]);
         cy.json({ elements: args["elements"] });
         elements = newElements;
-        initNodeActions(args["enableNodeActions"]);
+        initNodeActions(args["nodeActions"]);
         initToolbar();
         initViewbar();
     }
@@ -51,7 +51,7 @@ function onRender(event) {
             // default behavior
             cy.json({ elements: args["elements"] });
         } else {
-            // if nodeActions enabled & last action === expand
+            // if last action === expand
             const newNodes = cy
                 .add([
                     ...args["elements"]["nodes"],

--- a/st_link_analysis/frontend/src/style.css
+++ b/st_link_analysis/frontend/src/style.css
@@ -208,6 +208,7 @@ body {
 
     & .bar__item {
         height: 2.5rem;
+        display: none;
     }
 }
 


### PR DESCRIPTION
Added the `node_actions` parameter, allowing users to specify which node actions to enable (e.g., remove, expand, or both). This change also sets the stage for incorporating additional actions in the future. Thanks to @controllocked for the suggestion and feedback. 

As part of this update, the `enable_node_actions` parameter has been marked as deprecated.

--- 

Addresses issue #24 