### PR TITLE
feat(edgestyle): add `caption` param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   Added `node_actions` paramter to allow users to list which node actions to
+-   Added `node_actions` parameter to allow users to list which node actions to
     enable (e.g. `remove`, `expand`, or both).
     ([#28](https://github.com/AlrasheedA/st-link-analysis/pull/28))
+-   Added `caption` parameter for `EdgeStyle` to allow users to specify which edge
+    attribute to use as caption/label.
+    ([#30](https://github.com/AlrasheedA/st-link-analysis/pull/30))
 
 ### Changed
 
@@ -20,11 +23,15 @@ All notable changes to this project will be documented in this file.
 
 ### Deprecated
 
--   Depreceated the use of `enable_node_actions` paramter. `node_actions` should be
+-   Depreceated the use of `enable_node_actions` parameter. `node_actions` should be
     used instead to enable node actions. If `enable_node_actions` is set to True
     and `node_actions` is not provided, default actions ('remove', 'expand')
     will be enabled.
     ([#28](https://github.com/AlrasheedA/st-link-analysis/pull/28))
+-   Depreceated the use of `labeled` parameter for `EdgeStyle`. `caption` should be
+    used instead to specify edge caption/label. If `labeled` is set to True and `caption`
+    is not provided, default caption 'label' will be used.
+    ([#30](https://github.com/AlrasheedA/st-link-analysis/pull/30))
 
 ## [0.2.0] - 2024-08-03
 
@@ -56,7 +63,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   Prevent last selected node's icon from showing when selecting an edge.
--   Pass default layout paramters to cola and fcose layouts
+-   Pass default layout parameters to cola and fcose layouts
 -   Disable infopanel from expanding when selecting multiple elements
 
 ## [0.1.0] - 2024-07-11

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ node_styles = [
 ]
 
 edge_styles = [
-    EdgeStyle("FOLLOWS", labeled=True, directed=True),
-    EdgeStyle("POSTED", labeled=True, directed=True),
-    EdgeStyle("QUOTES", labeled=True, directed=True),
+    EdgeStyle("FOLLOWS", caption='label', directed=True),
+    EdgeStyle("POSTED", caption='label', directed=True),
+    EdgeStyle("QUOTES", caption='label', directed=True),
 ]
 
 # Render the component

--- a/examples/demos/edge_style.py
+++ b/examples/demos/edge_style.py
@@ -5,7 +5,7 @@ from st_link_analysis import st_link_analysis, NodeStyle, EdgeStyle
 with open("./data/social.json", "r") as f:
     elements = json.load(f)
 
-PERSON_ATTRS = list(elements["edges"][0]["data"].keys()) + [None]
+EDGE_ATTRS = ["id", "source", "target", "label", None]
 CURVE_STYLES = [
     "bezier",
     "haystack",
@@ -25,12 +25,13 @@ st.markdown(
     """
 )
 
-cols = st.columns((4, 1, 2, 5))
+c1, c2, c3, c4 = st.columns(4)
 label = "FOLLOWS"
-curve_style = cols[0].selectbox("Curve Style", CURVE_STYLES, index=0)
-color = cols[1].color_picker("Line Color", value="#808080")
-labeled = cols[2].checkbox("Labeled", value=False)
-directed = cols[2].checkbox("Directed", value=False)
+curve_style = c1.selectbox("Curve Style", CURVE_STYLES, index=0)
+caption = c2.selectbox("Caption", EDGE_ATTRS, index=3)
+directed = c3.selectbox("Directed", [True, False], index=0)
+color = c4.color_picker("Line Color", value="#808080")
+
 
 node_styles = [
     NodeStyle("PERSON", "#FF7F3E", "name", "person"),
@@ -38,9 +39,9 @@ node_styles = [
 ]
 
 edge_styles = [
-    EdgeStyle(label, color, labeled, directed, curve_style),
-    EdgeStyle("POSTED", labeled=True, directed=True),
-    EdgeStyle("QUOTES", labeled=True, directed=True),
+    EdgeStyle(label, color, caption, directed=directed, curve_style=curve_style),
+    EdgeStyle("POSTED", caption="label", directed=True),
+    EdgeStyle("QUOTES", caption="label", directed=True),
 ]
 
 layout = {"name": "cose", "animate": "end", "nodeDimensionsIncludeLabels": False}
@@ -55,9 +56,9 @@ with st.expander("Snippet", expanded=False, icon="💻"):
         from st_link_analysis import st_link_analysis, NodeStyle, EdgeStyle
         
         edge_styles = [
-            EdgeStyle({label=}, {color=}, {labeled=}, {directed=}, {curve_style=}),
-            EdgeStyle("POSTED", labeled=True, directed=True),
-            EdgeStyle("QUOTES", labeled=True, directed=True),
+            EdgeStyle({label=}, {color=}, {caption=}, {directed=}, {curve_style=}),
+            EdgeStyle("POSTED", caption='label', directed=True),
+            EdgeStyle("QUOTES", caption='label', directed=True),
         ]
 
         node_styles = [

--- a/examples/demos/event_listeners.py
+++ b/examples/demos/event_listeners.py
@@ -53,9 +53,9 @@ node_styles = [
 ]
 
 edge_styles = [
-    EdgeStyle("FOLLOWS", labeled=True, directed=True),
-    EdgeStyle("POSTED", labeled=True, directed=True),
-    EdgeStyle("QUOTES", labeled=True, directed=True),
+    EdgeStyle("FOLLOWS", caption="label", directed=True),
+    EdgeStyle("POSTED", caption="label", directed=True),
+    EdgeStyle("QUOTES", caption="label", directed=True),
 ]
 
 events = [
@@ -71,6 +71,7 @@ with st.container(border=True):
     st.markdown("#### Returned Value")
     st.json(vals or {}, expanded=True)
 
+
 @st.cache_data
 def get_source():
     with open(__file__, "r") as f:
@@ -81,4 +82,3 @@ def get_source():
 source = get_source()
 with st.expander("Source", expanded=False, icon="💻"):
     st.code(source, language="python")
-

--- a/examples/demos/node_actions.py
+++ b/examples/demos/node_actions.py
@@ -101,8 +101,8 @@ node_styles = [
 ]
 
 edge_styles = [
-    EdgeStyle("WORKS_AT", labeled=True, directed=True),
-    EdgeStyle("OWNED_BY", labeled=True, directed=True),
+    EdgeStyle("WORKS_AT", caption='label', directed=True),
+    EdgeStyle("OWNED_BY", caption='label', directed=True),
 ]
 
 

--- a/examples/demos/node_style.py
+++ b/examples/demos/node_style.py
@@ -28,9 +28,9 @@ node_styles = [
 ]
 
 edge_styles = [
-    EdgeStyle("FOLLOWS", labeled=True, directed=True),
-    EdgeStyle("POSTED", labeled=True, directed=True),
-    EdgeStyle("QUOTES", labeled=True, directed=True),
+    EdgeStyle("FOLLOWS", caption="label", directed=True),
+    EdgeStyle("POSTED", caption="label", directed=True),
+    EdgeStyle("QUOTES", caption="label", directed=True),
 ]
 
 layout = {"name": "cose", "animate": "end", "nodeDimensionsIncludeLabels": False}
@@ -50,9 +50,9 @@ with st.expander("Snippet", expanded=False, icon="💻"):
         ]
 
         edge_styles = [
-            EdgeStyle("FOLLOWS", labeled=True, directed=True),
-            EdgeStyle("POSTED", labeled=True, directed=True),
-            EdgeStyle("QUOTES", labeled=True, directed=True),
+            EdgeStyle("FOLLOWS", caption='label', directed=True),
+            EdgeStyle("POSTED", caption='label', directed=True),
+            EdgeStyle("QUOTES", caption='label', directed=True),
         ]
 
         layout = {{"name": "cose", "animate": "end", "nodeDimensionsIncludeLabels": False}}


### PR DESCRIPTION
Add `caption` parameter for `EdgeStyle` to allow users to specify which edge attribute to use as caption/label. Thanks to @DavidWalz for the feedback. 

As part of this update, the `labeled` parameter has been marked as deprecated.

--- 

Addresses issue #27 