### PR TITLE
fix(layouts): register cytoscape-dagre extension to enable Dagre layout

### DIFF
--- a/st_link_analysis/frontend/src/components/graph.js
+++ b/st_link_analysis/frontend/src/components/graph.js
@@ -1,6 +1,7 @@
 import cytoscape from "cytoscape";
 import fcose from "cytoscape-fcose";
 import cola from "cytoscape-cola";
+import dagre from "cytoscape-dagre";
 import State from "../utils/state";
 import { debounce, getCyInstance, debouncedSetValue } from "../utils/helpers";
 import STYLES from "../utils/styles";
@@ -8,6 +9,7 @@ import STYLES from "../utils/styles";
 // Register cytoscape extensions
 cytoscape.use(fcose);
 cytoscape.use(cola);
+cytoscape.use(dagre);
 
 // Constants & configurations
 const CY_ID = "cy";


### PR DESCRIPTION
Imported and registered cytoscape-dagre in the frontend under `graph.js` 
This should resolve #45 