### PR TITLE
fix(styles): prevent repeated .svg extension in NodeStyle icon path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 node_modules
 .vscode
 .venv
+/examples/debug/*.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   Added support for the **Dagre** layout by including the `cytoscape-dagre` dependency.
+-   Support for the **Dagre** layout by including the `cytoscape-dagre` dependency.
     Thanks to @drachenbach for the PR.  ([#39](https://github.com/AlrasheedA/st-link-analysis/pull/39))
--   Added 9 new Material icons to frontend assets. ([#47](https://github.com/AlrasheedA/st-link-analysis/pull/47))
+-   9 new Material icons to frontend assets. ([#47](https://github.com/AlrasheedA/st-link-analysis/pull/47))
+-   Support for dynamically loading debug pages from the `examples/debug/` directory in demo's `app.py`
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 -   9 new Material icons to frontend assets. ([#47](https://github.com/AlrasheedA/st-link-analysis/pull/47))
 -   Support for dynamically loading debug pages from the `examples/debug/` directory in demo's `app.py`
 
+### Fixed
+-   Prevent accumulating multiple `.svg` extensions on repeated calls of `dump` 
+    method with the same initialization of `NodeStyle` ([#48](https://github.com/AlrasheedA/st-link-analysis/issues/48))
 
 ### Changed
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 
 st.set_page_config(layout="wide")
@@ -31,13 +32,11 @@ node_style = st.Page(
 edge_style = st.Page(
     "./demos/edge_style.py",
     title="Edge Styles",
-)  #TODO: use multi-edge graph example for edge styles
+)  # TODO: use multi-edge graph example for edge styles
 layout = st.Page(
     "./demos/layout.py",
     title="Layout Algorithms",
 )
-
-#TODO: Return Selection
 
 # --------- Advanced Usage ---------
 event_listeners = st.Page(
@@ -50,14 +49,26 @@ node_actions = st.Page(
     title="Node Actions",
 )
 
-#TODO: Further Styling
-#TODO: Customized Layouts
+# TODO: Further Styling
+# TODO: Customized Layouts
 
-pg = st.navigation(
-    {
-        "Documentation": [home, changelog, license, icons],
-        "Demos": [node_style, edge_style, layout],
-        "Advanced Usage": [event_listeners, node_actions],
-    }
-)
+
+# --------- Navigation ---------
+menu = {
+    "Documentation": [home, changelog, license, icons],
+    "Demos": [node_style, edge_style, layout],
+    "Advanced Usage": [event_listeners, node_actions],
+}
+
+# --------- Debugging ---------
+debug_pages = [
+    st.Page(f"./debug/{file}", title=file.replace(".py", ""))
+    for file in os.listdir("./debug")
+    if file.endswith(".py")
+]
+
+if debug_pages:
+    menu["Debugging"] = debug_pages
+
+pg = st.navigation(menu)
 pg.run()

--- a/st_link_analysis/component/styles.py
+++ b/st_link_analysis/component/styles.py
@@ -56,7 +56,7 @@ class NodeStyle:
         if self.caption:
             style["label"] = f"data({self.caption})"
         if self.icon:
-            if not self.icon.startswith("url"):
+            if not self.icon.startswith("url") and not self.icon.endswith(".svg"):
                 self.icon = f"./icons/{self.icon.lower()}.svg"
             style["background-image"] = self.icon
 


### PR DESCRIPTION
- Fixed accumulating multiple `.svg` extensions on repeated calls of `dump` method with the same initialization of `NodeStyle` ([#48](https://github.com/AlrasheedA/st-link-analysis/issues/48))
- Added support for dynamically loading debug pages from the `examples/debug/` directory in demo's `app.py`