### PR TITLE
add boilerplate functions for better print() output of styles

### DIFF
--- a/st_link_analysis/component/styles.py
+++ b/st_link_analysis/component/styles.py
@@ -64,6 +64,13 @@ class NodeStyle:
             "style": style,
         }
 
+    def __str__(self) -> str:
+        properties = ', '.join(f"{key}='{value}'" for key, value in vars(self).items())
+        return f"{self.__class__.__name__}({properties})"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
 
 class EdgeStyle:
     def __init__(
@@ -143,3 +150,10 @@ class EdgeStyle:
             "selector": selector,
             "style": style,
         }
+        
+    def __str__(self) -> str:
+        properties = ', '.join(f"{key}='{value}'" for key, value in vars(self).items())
+        return f"{self.__class__.__name__}({properties})"
+
+    def __repr__(self) -> str:
+        return self.__str__()


### PR DESCRIPTION
These simple functions allow for easier debug so the style classes play nice with print()

print() now outputs:
```
 EdgeStyle(label='MY_LABEL', color='None', caption='label', directed='True', curve_style='None')
 ```

 instead of:
```
<st_link_analysis.component.styles.EdgeStyle object at 0x7f6bb9ac9fd0>
```

