### PR TITLE
Allow custom styling of nodes and edges

### DIFF
--- a/st_link_analysis/component/styles.py
+++ b/st_link_analysis/component/styles.py
@@ -38,8 +38,8 @@ class NodeStyle:
             or by url (e.g. url('...')). A list of supported icons is available
             in `st_link_analysis.component.icons`
         custom_styles: Optional[dict]
-            A dictionary of additional styles that will be applied to the edge. This
-            allows for control of any valid styles to be applied to the edge beyond basic
+            A dictionary of additional styles that will be applied to the node. This
+            allows for control of any valid styles to be applied to the node beyond basic
             options provided by python constructor. For detailed information on styles that can be set, visit: https://js.cytoscape.org/#style
 
         Example

--- a/st_link_analysis/component/styles.py
+++ b/st_link_analysis/component/styles.py
@@ -17,6 +17,7 @@ class NodeStyle:
         color: Optional[str] = None,
         caption: Optional[str] = None,
         icon: Optional[str] = None,
+        custom_styles: Optional[Dict] = None,
     ) -> None:
         """
         Define a custom style of a node in the graph based on label.
@@ -36,6 +37,10 @@ class NodeStyle:
             Node icon to be passed by the name of Material Icons (e.g. 'person')
             or by url (e.g. url('...')). A list of supported icons is available
             in `st_link_analysis.component.icons`
+        custom_styles: Optional[dict]
+            A dictionary of additional styles that will be applied to the edge. This
+            allows for control of any valid styles to be applied to the edge beyond basic
+            options provided by python constructor. For detailed information on styles that can be set, visit: https://js.cytoscape.org/#style
 
         Example
         -------
@@ -45,6 +50,7 @@ class NodeStyle:
         self.color = color
         self.caption = caption
         self.icon = icon
+        self.custom_styles = custom_styles
 
     def dump(self) -> Dict[str, Any]:
         selector = f"node[label='{self.label}']"
@@ -58,6 +64,9 @@ class NodeStyle:
             if not self.icon.startswith("url") and not self.icon.endswith(".svg"):
                 self.icon = f"./icons/{self.icon.lower()}.svg"
             style["background-image"] = self.icon
+        if self.custom_styles:
+            for key, val in self.custom_styles.items():
+                style[key] = val
 
         return {
             "selector": selector,
@@ -74,6 +83,7 @@ class EdgeStyle:
         labeled: bool = False,  # deprecated
         directed: bool = False,
         curve_style: Optional[str] = None,
+        custom_styles: Optional[Dict] = None,
     ) -> None:
         """
         Define a custom style of an edge in the graph based on label.
@@ -102,6 +112,10 @@ class EdgeStyle:
             "bezier", which is suitable for multigraphs. For large, simple graphs,
             consider using "haystack" for better performance. For more options
             and detailed information,visit: https://js.cytoscape.org/#style/edge-line
+        custom_styles: Optional[dict]
+            A dictionary of additional styles that will be applied to the edge. This
+            allows for control of any valid styles to be applied to the edge beyond basic
+            options provided by python constructor. For detailed information on styles that can be set, visit: https://js.cytoscape.org/#style
 
         Example
         -------
@@ -112,6 +126,7 @@ class EdgeStyle:
         self.caption = caption
         self.directed = directed
         self.curve_style = curve_style
+        self.custom_styles = custom_styles
 
         # TODO: remove in next version along with imports, docs, and signature
         if labeled is not None:
@@ -138,6 +153,9 @@ class EdgeStyle:
             style["target-arrow-shape"] = "triangle"
         if self.curve_style:
             style["curve-style"] = self.curve_style
+        if self.custom_styles:
+            for key, val in self.custom_styles.items():
+                style[key] = val
 
         return {
             "selector": selector,


### PR DESCRIPTION
Add an additional (optional) arg for NodeStyle() and EdgeStyle() constructors to pass additional style args to cytoscape.js as a dictionary that is applied directly to component.  This allows you to set style properties that are not set by one of the default parameters of the styles.

Example usage
```
NodeStyle("SKU", "blue", "name", "sku_icon", custom_styles={"width":5,"height":5})
```
or to change the width of an edge style:
```
EdgeStyle("QUOTES", caption='label', directed=True, custom_styles={"width":10})
```

Theoretically, this should allow you to pass any style(s) defined in cytoscape.js
https://js.cytoscape.org/#style
